### PR TITLE
Potential fix for code scanning alert no. 7: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/app/models/book_cover_fetcher.rb
+++ b/app/models/book_cover_fetcher.rb
@@ -1,6 +1,6 @@
 # app/services/book_cover_fetcher.rb
 require "httparty"
-require "open-uri"
+require "net/http"
 require "cgi"
 
 class BookCoverFetcher
@@ -38,9 +38,11 @@ class BookCoverFetcher
   end
 
   def download_to_tempfile
-    file = URI.open(source_url)
+    response = Net::HTTP.get_response(URI.parse(source_url))
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
     tempfile = Tempfile.new([ "cover", ".jpg" ], binmode: true)
-    tempfile.write(file.read)
+    tempfile.write(response.body)
     tempfile.rewind
     File.open(tempfile)
   rescue => e


### PR DESCRIPTION
Potential fix for [https://github.com/EricRoos/ReadRitual/security/code-scanning/7](https://github.com/EricRoos/ReadRitual/security/code-scanning/7)

To fix the issue, replace the usage of `URI.open(source_url)` with a safer alternative. Specifically, use `Net::HTTP` to fetch the remote resource instead of `URI.open`. This avoids the internal call to `Kernel.open` and mitigates the risk of command injection. The `Net::HTTP` library provides a secure way to make HTTP requests and retrieve data.

The changes will involve:
1. Replacing `URI.open(source_url)` with `Net::HTTP.get_response(URI.parse(source_url))`.
2. Reading the response body and writing it to the temporary file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
