### PR TITLE
Potential fix for code scanning alert no. 8: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,3 +1,4 @@
+require "net/http"
 class Book < ApplicationRecord
   attr_accessor :skip_auto_cover
 
@@ -82,7 +83,8 @@ class Book < ApplicationRecord
     return if cover_image.attached?
 
     begin
-      file = URI.open(cover_url)
+      response = Net::HTTP.get(URI.parse(cover_url))
+      file = StringIO.new(response)
       cover_image.attach(io: file, filename: "#{title}.jpg", content_type: "image/jpeg")
     rescue OpenURI::HTTPError => e
       Rails.logger.error("Failed to fetch cover image from URL: #{e.message}")


### PR DESCRIPTION
Potential fix for [https://github.com/EricRoos/ReadRitual/security/code-scanning/8](https://github.com/EricRoos/ReadRitual/security/code-scanning/8)

To address the issue, replace the use of `URI.open` with a safer alternative that does not rely on `Kernel.open`. Specifically, use `Net::HTTP` to fetch the content of the URL. This approach avoids the security risks associated with `Kernel.open` and provides better control over HTTP requests.

The fix involves:
1. Replacing `URI.open(cover_url)` with `Net::HTTP.get(URI.parse(cover_url))` to fetch the content of the URL.
2. Wrapping the fetched content in a `StringIO` object to simulate a file-like object for attaching the cover image.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
