### PR TITLE
Potential fix for code scanning alert no. 6: URL redirection from remote source

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,23 +1,21 @@
-require 'uri'
+require "uri"
 
 class ApplicationController < ActionController::Base
   include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   # allow_browser versions: :modern
 
-  TRUSTED_HOST = "example.org".freeze
-
   def return_or_redirect_to(path, options = {})
-    redirect_to validated_return_to_or_path(path), options
+    redirect_to return_to_or_path(path), options
   end
 
-  def validated_return_to_or_path(path)
+  def return_to_or_path(path)
     return_to = params[:return_to]
     if return_to.present?
       begin
         uri = URI.parse(return_to)
         # Allow relative URLs or URLs with the trusted host
-        if uri.host.nil? || uri.host == TRUSTED_HOST
+        if uri.host.nil?
           return uri.to_s
         end
       rescue URI::InvalidURIError


### PR DESCRIPTION
Potential fix for [https://github.com/EricRoos/ReadRitual/security/code-scanning/6](https://github.com/EricRoos/ReadRitual/security/code-scanning/6)

To fix the issue, we need to validate the `params[:return_to]` value before using it in the `redirect_to` method. This can be achieved by implementing one of the following approaches:
1. **Whitelist validation:** Maintain a list of allowed URLs and validate `params[:return_to]` against this list.
2. **Host validation:** Ensure that the URL is either relative or belongs to a known trusted host.
3. **Fallback mechanism:** Redirect to a safe default path if the validation fails.

For this fix, we will implement host validation to ensure that the URL is either relative or belongs to a known trusted host. This approach is flexible and avoids hardcoding specific URLs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
