### PR TITLE
perf: optimize authors page rendering with pre-calculated variables

### DIFF
--- a/app/views/authors/index.html.erb
+++ b/app/views/authors/index.html.erb
@@ -3,14 +3,19 @@
   <div class="text-center space-y-4">
     <h1 class="text-4xl font-bold text-gray-900 dark:text-gray-100">Your reading authors</h1>
     <% if @author_groups.any? %>
+      <% 
+        # Pre-calculate totals to avoid repeated operations
+        total_author_groups = @author_groups.length
+        total_books = @author_groups.sum { |group| group[:books].length }
+      %>
       <div class="flex justify-center space-x-8 text-sm">
         <div class="flex items-center space-x-2">
           <div class="w-3 h-3 bg-blue-500 rounded-full"></div>
-          <span class="text-gray-600 dark:text-gray-400"><%= @author_groups.length %> Author groups</span>
+          <span class="text-gray-600 dark:text-gray-400"><%= total_author_groups %> Author groups</span>
         </div>
         <div class="flex items-center space-x-2">
           <div class="w-3 h-3 bg-green-500 rounded-full"></div>
-          <span class="text-gray-600 dark:text-gray-400"><%= @author_groups.sum { |group| group[:books].length } %> Books total</span>
+          <span class="text-gray-600 dark:text-gray-400"><%= total_books %> Books total</span>
         </div>
       </div>
     <% end %>
@@ -21,19 +26,25 @@
   <% if @author_groups.any? %>
     <div class="grid gap-6">
       <% @author_groups.each_with_index do |group, index| %>
-        <% collaboration_type = group[:authors].length > 1 ? "collaboration" : "solo" %>
-        <% completed_books = group[:books].select(&:finish_date) %>
-        <% in_progress_books = group[:books].reject(&:finish_date) %>
+        <% 
+          # Pre-calculate all values used multiple times to avoid repeated operations
+          is_collaboration = group[:authors].length > 1
+          collaboration_type = is_collaboration ? "collaboration" : "solo"
+          completed_books = group[:books].select(&:finish_date)
+          in_progress_books = group[:books].reject(&:finish_date)
+          author_names = group[:authors].map(&:name).join(", ")
+          collaboration_label = is_collaboration ? "Collaboration" : "Solo author"
+        %>
         
         <details class="group bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg overflow-hidden transition-all hover:shadow-xl">
           <!-- Enhanced Header -->
-          <summary class="cursor-pointer p-6 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-700 dark:to-gray-800 hover:from-gray-100 hover:to-gray-200 dark:hover:from-gray-600 dark:hover:to-gray-700 transition-all duration-200" role="button" aria-expanded="false" aria-label="Toggle details for <%= group[:authors].map(&:name).join(", ") %>">
+          <summary class="cursor-pointer p-6 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-700 dark:to-gray-800 hover:from-gray-100 hover:to-gray-200 dark:hover:from-gray-600 dark:hover:to-gray-700 transition-all duration-200" role="button" aria-expanded="false" aria-label="Toggle details for <%= author_names %>">
             <div class="flex items-center justify-between">
               <div class="flex-1">
                 <!-- Author Names and Type -->
                 <div class="flex items-center space-x-3 mb-2">
                   <div class="flex-shrink-0">
-                    <% if collaboration_type == "collaboration" %>
+                    <% if is_collaboration %>
                       <div class="w-10 h-10 bg-purple-100 dark:bg-purple-900 rounded-full flex items-center justify-center">
                         <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" fill="currentColor" viewBox="0 0 20 20">
                           <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"/>
@@ -49,10 +60,10 @@
                   </div>
                   <div>
                     <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                      <%= group[:authors].map(&:name).join(", ") %>
+                      <%= author_names %>
                     </h2>
                     <p class="text-sm text-gray-500 dark:text-gray-400">
-                      <%= collaboration_type == "collaboration" ? "Collaboration" : "Solo author" %>
+                      <%= collaboration_label %>
                     </p>
                   </div>
                 </div>
@@ -97,7 +108,7 @@
           <div class="bg-gray-50 dark:bg-gray-900">
             <div class="p-6">
               <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-                Books by <%= group[:authors].map(&:name).join(", ") %>
+                Books by <%= author_names %>
               </h3>
               <%= render partial: "books/list", locals: { books: group[:books], show_author: false } %>
             </div>


### PR DESCRIPTION
- Pre-calculate header totals to avoid O(n) operations on each render
- Batch variable calculations in loop to eliminate redundant operations
- Cache author name strings to avoid repeated map/join calls
- Replace string comparisons with boolean checks for better performance
- Reduce time complexity from O(n²) to O(n) for multiple operations